### PR TITLE
Upload photos in the order that they are rendered by the export service.

### DIFF
--- a/500pxExportServiceProvider.lua
+++ b/500pxExportServiceProvider.lua
@@ -673,7 +673,7 @@ function getPhotoInfo( exportContext )
 		if PluginInit then PluginInit.unlock() end
 
 		end
-		photos[ rendition ] = photoInfo
+		table.insert( photos, { ["rendition"] = rendition, ["photoInfo"] = photoInfo } )
 	end
 
 	return photos
@@ -832,8 +832,9 @@ function exportServiceProvider.processRenderedPhotos( functionContext, exportCon
 		logger:trace( "Upload limit: " .. tostring(uploadLimit) )
 		local uploadCount = 0
 
-		local i = 1
-		for rendition, photoInfo in pairs( photos ) do
+		for i, data in pairs( photos ) do
+			local rendition = data.rendition
+			local photoInfo = data.photoInfo
 			progressScope:setPortionComplete( ( i - 1 ) / nPhotos )
 			local photo = rendition.photo
 			if not photoInfo.skipped and not photoInfo.failed then
@@ -973,7 +974,6 @@ function exportServiceProvider.processRenderedPhotos( functionContext, exportCon
 
 				LrFileUtils.delete( photoInfo.path )
 				progressScope:setPortionComplete( ( i - 0.5 ) / nPhotos )
-				i = i + 1
 			end
 		end
 


### PR DESCRIPTION
When uploading photos from Lightroom I expect them to be uploaded in the order shown in the Lightroom UI. This allows me to say upload in order of capture date so the photos present a timeline on the website. Currently photos upload randomly. This pull request fixes that.
