### PR TITLE
Retain category, nsfw and license properties when photos are deleted from 500px

### DIFF
--- a/500pxPublishSupport.lua
+++ b/500pxPublishSupport.lua
@@ -123,12 +123,9 @@ function publishServiceProvider.deletePhotosFromPublishedCollection( publishSett
 							photo:setPropertyForPlugin( _PLUGIN, "views", nil )
 							photo:setPropertyForPlugin( _PLUGIN, "favorites", nil )
 							photo:setPropertyForPlugin( _PLUGIN, "votes", nil )
-							photo:setPropertyForPlugin( _PLUGIN, "category", nil )
 							photo:setPropertyForPlugin( _PLUGIN, "publishedUUID", nil )
 							photo:setPropertyForPlugin( _PLUGIN, "previous_tags", nil )
 							photo:setPropertyForPlugin( _PLUGIN, "privacy", nil )
-							photo:setPropertyForPlugin( _PLUGIN, "nsfw", nil )
-							photo:setPropertyForPlugin( _PLUGIN, "license_type", nil )
 						end
 					end
 				end
@@ -269,12 +266,9 @@ function publishServiceProvider.willDeletePublishService( publishSettings, info 
 		photo:setPropertyForPlugin( _PLUGIN, "favorites", nil )
 		photo:setPropertyForPlugin( _PLUGIN, "votes", nil )
 		photo:setPropertyForPlugin( _PLUGIN, "previous_tags", nil )
-		photo:setPropertyForPlugin( _PLUGIN, "category", nil )
-		photo:setPropertyForPlugin( _PLUGIN, "nsfw", nil )
 		photo:setPropertyForPlugin( _PLUGIN, "publishedUUID", nil )
 		photo:setPropertyForPlugin( _PLUGIN, "photoId", nil )
 		photo:setPropertyForPlugin( _PLUGIN, "privacy", nil )
-		photo:setPropertyForPlugin( _PLUGIN, "license_type", nil )
 	end
 end
 


### PR DESCRIPTION
I don't think it makes sense to delete these properties when removing a photo from the publish service. These are user-set properties and I certainly would rather that once set I can be sure I won't have to go back and reset them if I choose to unpublish the photo and then republish it in a different account or something.
