### PR TITLE
Avoid dropping recently published photos from collections

### DIFF
--- a/500pxExportServiceProvider.lua
+++ b/500pxExportServiceProvider.lua
@@ -772,6 +772,18 @@ function exportServiceProvider.processRenderedPhotos( functionContext, exportCon
 		end
 	end
 
+	if publishedCollection then
+		LrApplication:activeCatalog():withReadAccessDo( function()
+			for _, photo in ipairs( publishedCollection:getPublishedPhotos() ) do
+				local pid = photo:getPhoto():getPropertyForPlugin( _PLUGIN, "photoId" )
+				if pid and not string.match( photoList, string.format( ",%s,", pid ) ) then
+					logger:trace( "Added missing photo to list: " .. pid )
+					photoList = string.format( "%s%i,", photoList, pid )
+				end
+			end
+		end )
+	end
+
 	-- create the collection if it doesn't already exist
 	if not remoteCollection and not publishedCollectionInfo.isDefaultCollection then
 		if not propertyTable.isUserAwesome and not propertyTable.isUserPlus then
@@ -801,8 +813,8 @@ function exportServiceProvider.processRenderedPhotos( functionContext, exportCon
 				if publishedCollection then
 					for _, photo in ipairs( publishedCollection:getPublishedPhotos() ) do
 						local pid
-						LrApplication:activeCatalog():withReadAccessDo( "", function()
-							pid = photo.photo:getPropertyForPlugin( _PLUGIN, "photoId" )
+						LrApplication:activeCatalog():withReadAccessDo( function()
+							pid = photo:getPhoto():getPropertyForPlugin( _PLUGIN, "photoId" )
 						end )
 
 						LrApplication:activeCatalog():withWriteAccessDo( "", function()
@@ -821,7 +833,7 @@ function exportServiceProvider.processRenderedPhotos( functionContext, exportCon
 	end
 
 	if isPublish then
-		logger:trace( "Colection: " .. publishedCollectionInfo.name )
+		logger:trace( "Collection: " .. publishedCollectionInfo.name )
 		logger:trace( "URL: " .. publishedCollectionInfo.remoteUrl )
 		logger:trace( "ID: " .. publishedCollectionInfo.remoteId )
 	end


### PR DESCRIPTION
A bug in the collections API (https://github.com/500px/api-documentation/issues/83) means the plugin will sometimes remove recently published photos from collections if you immediately do something else like publish more photos or delete photos from the same collection. The solution here works by scanning the photos marked as already published locally and adding them to the list of photos in the collection returned by the API.

The downside is that this would re-add any photos to the collection that a user had manually removed through the web interface. To me that seems ok, it means that publishing a collection in Lightroom makes the remote collection match what you see locally in Lightroom but I can understand if that might be surprising to some. I'm not seeing an obvious other solution that doesn't involve fixes to the API though.
