### PR TITLE
Convert LINE SEPARATOR to newlines for textual data in API calls

### DIFF
--- a/500pxAPI.lua
+++ b/500pxAPI.lua
@@ -170,6 +170,16 @@ end
 
 PxAPI = {  }
 
+function PxAPI.encodeString( str )
+	-- Lightroom uses the unicode LINE SEPARATOR but the API uses to more regular newline.
+	return string.gsub( str, string.char( 0xE2, 0x80, 0xA8 ), "\n" )
+end
+
+function PxAPI.decodeString( str )
+	-- Lightroom uses the unicode LINE SEPARATOR but the API uses to more regular newline.
+	return string.gsub( str, "\n", string.char( 0xE2, 0x80, 0xA8 ) )
+end
+
 function PxAPI.makeCollectionUrl( domain, path )
 	if domain and path then
 		return "http://500px.com/" .. domain .. "/sets/" .. path

--- a/500pxExportServiceProvider.lua
+++ b/500pxExportServiceProvider.lua
@@ -879,8 +879,8 @@ function exportServiceProvider.processRenderedPhotos( functionContext, exportCon
 
 				local args = {
 					photo_id = photoid,
-					name = photoInfo.title,
-					description = photoInfo.description,
+					name = PxAPI.encodeString( photoInfo.title ),
+					description = PxAPI.encodeString( photoInfo.description ),
 					category = photoInfo.category,
 					privacy = photoInfo.privacy,
 					nsfw = booleanToNumber( photoInfo.nsfw ),

--- a/500pxPublishSupport.lua
+++ b/500pxPublishSupport.lua
@@ -314,7 +314,7 @@ function publishServiceProvider.getCommentsFromPublishedCollection( publishSetti
 					for _, comment in ipairs( comments) do
 						table.insert( commentList, {
 							commentId = comment.id,
-							commentText = comment.body,
+							commentText = PxAPI.decodeString( comment.body ),
 							dateCreated = formatDate( comment.created_at ),
 							username = comment.user.username,
 							realname = comment.user.fullname,
@@ -381,7 +381,7 @@ function publishServiceProvider.addCommentToPublishedPhoto( publishSettings, rem
 	local photoId, collectionId = string.match( remotePhotoId, "([^-]+)-([^-]+)" )
 	local success, _ = PxAPI.postComment( publishSettings, {
 		photo_id = photoId,
-		body = commentText,
+		body = PxAPI.encodeString( commentText ),
 	} )
 	return success
 end

--- a/500pxUser.lua
+++ b/500pxUser.lua
@@ -190,8 +190,8 @@ function PxUser.sync( propertyTable )
 					if photoInfo then
 						local photo = photoInfo.photo
 						if not photoInfo.edited then
-							photo:setRawMetadata( "title", photoObj.name or "" )
-							photo:setRawMetadata( "caption", photoObj.description or "" )
+							photo:setRawMetadata( "title", PxAPI.decodeString( photoObj.name or "" ) )
+							photo:setRawMetadata( "caption", PxAPI.decodeString( photoObj.description or "" ) )
 
 							if photoObj.category and photoObj.category > 0 then
 								photo:setPropertyForPlugin( _PLUGIN, "category", photoObj.category )


### PR DESCRIPTION
Lightroom uses the unicode LINE SEPARATOR character for newlines so this converts those for the appropriate fields before making API calls. I've done the reverse too for consistency though it isn't strictly necessary.
