### PR TITLE
Use x_auth to login after creating a new account.

### DIFF
--- a/500pxUser.lua
+++ b/500pxUser.lua
@@ -682,6 +682,8 @@ function PxUser.register( propertyTable )
 			propertyTable.credentials = obj
 
 			PxUser.updateUserStatusTextBindings( propertyTable )
+		elseif obj.created then
+			LrDialogs.message( "Login Failed", "Your account was created but logging in failed. Please try logging in again later." )
 		elseif obj.email then
 			LrDialogs.message( "Unable to Create an Account", "The email address is not valid or has already been used. Please use a different email address." )
 		elseif obj.username then


### PR DESCRIPTION
df6c59f692fee545758775ca0b242118f6d42a91 broke signup which relied on using x_auth to login after creating the account. Sending the user through the web-browser authentication route doesn't make sense when we know they have a normal account so this brings back x_auth for just the register method.
