### PR TITLE
Check for updated versions of the plugin and notify the user.

### DIFF
--- a/500pxTagset.lua
+++ b/500pxTagset.lua
@@ -1,5 +1,5 @@
 if PluginInit then
-	--PluginInit.checkForUpdates()
+	PluginInit.checkForUpdates()
 	PluginInit.forceNewCollections()
 end
 

--- a/PluginInit.lua
+++ b/PluginInit.lua
@@ -21,8 +21,6 @@ end
 
 function PluginInit.checkForUpdates()
 	LrFunctionContext.postAsyncTaskWithContext( "Update Check", function(context)
-		LrDialogs.attachErrorDialogToFunctionContext(context)
-
 		local lastCheck = prefs.lastUpdateCheck
 		if not lastCheck then
 			lastCheck = 0


### PR DESCRIPTION
This replaces the old disabled update check code with something that works. At most once a day it will check for updates and if one is found notify the user. The user can opt out of receiving notifications for that version