### PR TITLE
Allow the user to choose the location to sync pictures to.

### DIFF
--- a/500pxUser.lua
+++ b/500pxUser.lua
@@ -135,11 +135,7 @@ function PxUser.sync( propertyTable )
 			image_size = 5,
 		}
 
-		local dir = propertyTable.LR_export_destinationPathPrefix
-		if propertyTable.LR_export_useSubfolder then
-			dir = LrPathUtils.child(dir, propertyTable.LR_export_destinationPathSuffix)
-		end
-
+		local dir = propertyTable.syncLocation
 		LrFileUtils.createAllDirectories( dir )
 
 		-- collect photos for "Profile" and "Library" collections


### PR DESCRIPTION
A previous commit turned on the export location section of the plugin's settings and uses that for the location to sync existing photos to. This isn't a good choice as any user that sets that will also see any future photos they publish get copied into the export location leaving a mess of things they have download but don't have elsewhere and copies of things they already have.

This reverts that and instead adds a method for the user to choose the sync folder separately. It's also a lot more obvious that they can do this this way.