### PR TITLE
Fix default collection names on startup and ignore a missing profile collection.

### DIFF
--- a/500pxExportServiceProvider.lua
+++ b/500pxExportServiceProvider.lua
@@ -792,7 +792,7 @@ function exportServiceProvider.processRenderedPhotos( functionContext, exportCon
 						end
 
 						-- add photo to "Profile"
-						if photoInfo.privacy == 0 and not publishedCollectionInfo.isProfileCollection then
+						if photoInfo.privacy == 0 and not publishedCollectionInfo.isProfileCollection and profileCollection then
 							profileCollection:addPhotoByRemoteId( photo, string.format( "%s-profile", photoInfo.id ), string.format( "https://500px.com/photo/%s", photoInfo.id ), true )
 						end
 					end )

--- a/PluginInit.lua
+++ b/PluginInit.lua
@@ -34,23 +34,24 @@ function PluginInit.forceNewCollections()
 			local allPhotosCollection
 			local profileCollection
 
-			catalog:withPrivateWriteAccessDo( "New Collections", function()
+			catalog:withWriteAccessDo( "New Collections", function()
 				for _, collection in ipairs( publishService:getChildCollections() ) do
-					if collection:getName() == "Library" or collection:getName() == "Organizer" then
+					local name = collection:getName():lower()
+					if name == "library" or name == "organizer" then
 						collection:setName( "Library" )
-						collection:setCollectionSettings( { toCummunity = false } )
+						collection:setCollectionSettings( { toCommunity = false } )
 						allPhotosCollection = collection
+					elseif name == "public profile" then
+						collection:setName( "Public Profile" )
 					end
 				end
 
 				profileCollection = publishService:createPublishedCollection( "Public Profile", nil, false )
 				if profileCollection then
-					profileCollection:setCollectionSettings( { toCummunity = true } )
+					profileCollection:setCollectionSettings( { toCommunity = true } )
 				end
-			end )
 
-			if profileCollection then
-				catalog:withWriteAccessDo( "", function()
+				if profileCollection then
 					for _, collection in ipairs( publishService:getChildCollections() ) do
 						local isAllPhotos = ( collection:getName() == "Library" )
 						for _, publishedPhoto in ipairs( collection:getPublishedPhotos() ) do
@@ -69,8 +70,8 @@ function PluginInit.forceNewCollections()
 							end
 						end
 					end
-				end )
-			end
+				end
+			end )
 		end
 	end )
 end


### PR DESCRIPTION
Some users report the following error: "attempt to index upvalue 'profileCollection' (a nil value)". There are only two places that that could be coming from. For one I've just added a guard around a nil profileCollection, it should never happen if the user's publish service is set up right.

The second would only happen if the user has a collection with the name that matches "Public Profile" but with a different case. To solve that and to help make sure the user's default collections are right I've fixed the code that runs on startup (it was silently failing before) and made it update the library and profile collection names to the correct case.