### PR TITLE
Sync shouldn't download a photo if one with a matching ID exists anywhere else in the catalog.

### DIFF
--- a/500pxUser.lua
+++ b/500pxUser.lua
@@ -56,6 +56,14 @@ local function getCollectionsAndPhotos( publishService )
 	local collectionsById = {}
 	local collectionsByName = {}
 
+	-- Find any photo in the entire catalog that has a remote ID
+	local known = publishService.catalog:findPhotosWithProperty( _PLUGIN.id, "photoId" )
+	local props = publishService.catalog:batchGetPropertyForPlugin( known, _PLUGIN, { "photoId" } )
+
+	for photo, fields in pairs( props ) do
+		photos[ fields[ "photoId" ] ] = { photo = photo, edited = False }
+	end
+
 	for _, publishedCollection in ipairs( publishedCollections ) do
 		local publishedPhotos = publishedCollection:getPublishedPhotos()
 		local collection = {}


### PR DESCRIPTION
Sync was only checking photos already in the publish service for matching photos before download. This makes it check the entire catalog so it doesn't download duplicate photos with the same ID